### PR TITLE
Set base URL for GitHub Pages

### DIFF
--- a/Kivilun/Kivilun/settings.py
+++ b/Kivilun/Kivilun/settings.py
@@ -116,7 +116,12 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
-STATIC_URL = 'static/'
+# Base path for deploying the project under a subdirectory, e.g. GitHub Pages
+# served from https://kivilun.github.io/outlook/
+FORCE_SCRIPT_NAME = '/outlook'
+
+# Static files will also be served from the same base path
+STATIC_URL = '/outlook/static/'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- configure `FORCE_SCRIPT_NAME` and `STATIC_URL` so that all generated links are relative to `https://kivilun.github.io/outlook/`

## Testing
- `python Kivilun/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6863803391708328b938dfd9b798d623